### PR TITLE
Update script suggested by issue 12

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,11 +1,16 @@
-#!/bin/bash
-#Linux CapsLock Delay Fixer by ErkanMDR /- HELYX
+#!/bin/sh
+rpl='key <CAPS> \{ repeat=no, type\[group1\]=\"ALPHABETIC\", symbols\[group1\]=\[ Caps_Lock, Caps_Lock \],actions\[group1\]=\[LockMods\(modifiers=Lock\),Private\(type=3,data\[0\]=1,data\[1\]=3,data\[2\]=3\) \] \}'
 
-cd "${BASH_SOURCE%/*}" || exit
+# Create copy of kb description
+xkbcomp -xkb $DISPLAY keyboardmap
 
-xkbcomp -xkb $DISPLAY xkbmap
-fixpatchline=$(cat fixpatch)
-perl -i~ -0777 -pe "s/key .CAPS[^}]+};/$fixpatchline/" xkbmap
-xkbcomp xkbmap $DISPLAY
-rm xkbmap*
-echo "Problem fixed ;)"
+# Replace CAPS
+sed -i "s/key <CAPS>[^;]*/$rpl/" keyboardmap
+
+# Apply
+xkbcomp keyboardmap $DISPLAY
+
+# Remove temp file
+rm keyboardmap
+
+# script provided by ben2talk and tprei at https://github.com/hexvalid/Linux-CapsLock-Delay-Fixer/issues/12


### PR DESCRIPTION
I'm making this pull request to add the script suggested by [ben2talk](https://github.com/ben2talk) and [tprei](https://github.com/tprei) at [this issue](https://github.com/hexvalid/Linux-CapsLock-Delay-Fixer/issues/12) because the script wasn't updated